### PR TITLE
Add AKS recover cluster objects from backup

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
+++ b/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
@@ -70,7 +70,7 @@ vault login -method=ldap username=<your username>
 +
 [source,bash]
 ----
-export RESTIC_REPOSITORY=azure:$(yq -r '. | select(.kind == "Schedule").spec.backend.s3.bucket' catalog/manifests/cluster-backup/05_schedule.yaml):/
+export RESTIC_REPOSITORY=azure:$(yq e '. | select(.kind == "Schedule").spec.backend.s3.bucket' catalog/manifests/cluster-backup/05_schedule.yaml):/
 
 PASSWORD_KEY="$(yq e '. | select(.kind == "Secret" and .metadata.name == "objects-backup-password").stringData.password' catalog/manifests/cluster-backup/05_schedule.yaml | cut -d: -f2)"
 export RESTIC_PASSWORD=$(vault kv get -format json "clusters/kv/${PASSWORD_KEY%/*}" | jq -r ".data.data.${PASSWORD_KEY##*/}")

--- a/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
+++ b/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
@@ -102,6 +102,13 @@ restic restore <ID> --target cluster-backup-object-restore-$(date +%F)
 
 == Extract and prepare files
 
+. Change the directory
++
+[source,console]
+----
+cd cluster-backup-object-restore-$(date +%F)
+----
+
 . List files in the backup.
    Take note of the path containing the required files.
 +

--- a/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
+++ b/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
@@ -10,10 +10,10 @@
 
 == General procedure
 
-1. Collect configuration for restic
-2. Identify and retrieve restic snapshot
-3. Extract files containing the desired objects and prepare them
-4. Apply objects to the cluster
+. Collect configuration for restic
+. Identify and retrieve restic snapshot
+. Extract files containing the desired objects and prepare them
+. Apply objects to the cluster
 
 == Collect restic configuration
 
@@ -33,7 +33,7 @@ export AZURE_ACCOUNT_KEY=$(kubectl get secret admin-credentials-minio-k8up -n sy
 
 === Obtaining restic configuration from catalog and vault
 
-1. Obtain the repository URL of the cluster's catalog and export it to `REPO_URL`
+. Obtain the repository URL of the cluster's catalog and export it to `REPO_URL`
 +
 Get the URL from https://control.vshn.net/syn/lieutenantclusters.
 Alternatively, get it from the Lieutenant API or the Kubernetes API Lieutenant is running on.
@@ -50,7 +50,7 @@ REPO_URL=$(curl -sH "${LIEUTENANT_AUTH}" "https://${LIEUTENANT_URL}/clusters/${C
 REPO_URL=$(kubectl -n ${LIEUTENANT_NS} get cluster -o jsonpath='{.spec.gitRepoURL}' ${CLUSTER_ID})
 ----
 
-2. Download and extract the cluster catalog
+. Download and extract the cluster catalog
 +
 [source,console]
 ----
@@ -58,7 +58,7 @@ mkdir catalog
 git archive --remote ${REPO_URL} master | tar -xC catalog
 ----
 
-3. Login to Vault
+. Login to Vault
 +
 [source,console]
 ----
@@ -66,7 +66,7 @@ export VAULT_ADDR=https://vault-prod.syn.vshn.net
 vault login -method=ldap username=<your username>
 ----
 
-4. Export restic configuration
+. Export restic configuration
 +
 [source,console]
 ----
@@ -102,7 +102,7 @@ restic restore <ID> --target cluster-backup-object-restore-$(date +%F)
 
 == Extract and prepare files
 
-1. List files in the backup.
+. List files in the backup.
    Take note of the path containing the required files.
 +
 [source,console]
@@ -110,7 +110,7 @@ restic restore <ID> --target cluster-backup-object-restore-$(date +%F)
 tar tvf syn-cluster-backup-object-dumper.tar.gz
 ----
 
-2. Extract required files.
+. Extract required files.
    If all files should be extracted, `path/inside/archive` can be omitted.
    Files will be put in the directory `restore` within the current working directory.
 +
@@ -120,7 +120,7 @@ mkdir restore
 tar -C restore -xf syn-cluster-backup-object-dumper.tar.gz [path/inside/archive]
 ----
 
-3. Prepare files
+. Prepare files
 +
 Depending on the restore requirements, the extracted files need to be altered before they can be applied to the cluster.
 

--- a/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
+++ b/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
@@ -84,16 +84,16 @@ export AZURE_ACCOUNT_KEY=$(vault kv get -format json "clusters/kv/${SECRET_KEY%/
 
 == Identify and retrieve snapshot
 
-1. List the available snapshots.
+. List the available snapshots.
    Identify the one you do want to restore.
    Take note of its `ID`.
 +
-[source,console]
+[source,bash]
 ----
 restic snapshots
 ----
 
-2. Retrieve the backup archive
+. Retrieve the backup archive
 +
 [source,console]
 ----

--- a/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
+++ b/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
@@ -58,7 +58,7 @@ mkdir catalog
 git archive --remote ${REPO_URL} master | tar -xC catalog
 ----
 
-3. Login to vault
+3. Login to Vault
 +
 [source,console]
 ----

--- a/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
+++ b/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
@@ -102,7 +102,7 @@ restic restore <ID> --target cluster-backup-object-restore-$(date +%F)
 
 == Extract and prepare files
 
-. Change the directory
+. Change to the restore directory
 +
 [source,console]
 ----

--- a/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
+++ b/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
@@ -72,13 +72,13 @@ vault login -method=ldap username=<your username>
 ----
 export RESTIC_REPOSITORY=azure:$(yq -r '. | select(.kind == "Schedule").spec.backend.s3.bucket' catalog/manifests/cluster-backup/05_schedule.yaml):/
 
-PASSWORD_KEY="$(yq -r '. | select(.kind == "Secret" and .metadata.name == "objects-backup-password").stringData.password' catalog/manifests/cluster-backup/05_schedule.yaml | cut -d: -f2)"
+PASSWORD_KEY="$(yq e '. | select(.kind == "Secret" and .metadata.name == "objects-backup-password").stringData.password' catalog/manifests/cluster-backup/05_schedule.yaml | cut -d: -f2)"
 export RESTIC_PASSWORD=$(vault kv get -format json "clusters/kv/${PASSWORD_KEY%/*}" | jq -r ".data.data.${PASSWORD_KEY##*/}")
 
-ID_KEY="$(yq -r '. | select(.kind == "Secret" and .metadata.name == "object-backup-s3-credentials").stringData.username' catalog/manifests/cluster-backup/05_schedule.yaml | cut -d: -f2)"
+ID_KEY="$(yq e '. | select(.kind == "Secret" and .metadata.name == "object-backup-s3-credentials").stringData.username' catalog/manifests/cluster-backup/05_schedule.yaml | cut -d: -f2)"
 export AZURE_ACCOUNT_NAME=$(vault kv get -format json "clusters/kv/${ID_KEY%/*}" | jq -r ".data.data.${ID_KEY##*/}")
 
-SECRET_KEY="$(yq -r '. | select(.kind == "Secret" and .metadata.name == "object-backup-s3-credentials").stringData.password' catalog/manifests/cluster-backup/05_schedule.yaml | cut -d: -f2)"
+SECRET_KEY="$(yq e '. | select(.kind == "Secret" and .metadata.name == "object-backup-s3-credentials").stringData.password' catalog/manifests/cluster-backup/05_schedule.yaml | cut -d: -f2)"
 export AZURE_ACCOUNT_KEY=$(vault kv get -format json "clusters/kv/${SECRET_KEY%/*}" | jq -r ".data.data.${SECRET_KEY##*/}")
 ----
 

--- a/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
+++ b/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
@@ -1,0 +1,141 @@
+= AKS Recover cluster objects from Azure Blob Storage backup
+
+== Prerequisites
+
+* Executables used in this guide:
+** `kubectl`
+** `yq`
+** `restic`
+* API access to the target cluster
+
+== General procedure
+
+1. Collect configuration for restic
+2. Identify and retrieve restic snapshot
+3. Extract files containing the desired objects and prepare them
+4. Apply objects to the cluster
+
+== Collect restic configuration
+
+Restic requires the environment variables `RESTIC_REPOSITORY`, `RESTIC_PASSWORD`, `AZURE_ACCOUNT_NAME` and `AZURE_ACCOUNT_KEY` to be set.
+They can be obtained from the target cluster itself.
+They can also be obtained from the cluster catalog and Vault.
+
+=== Obtaining restic configuration from cluster
+
+[source,console]
+----
+export RESTIC_REPOSITORY=$(kubectl -n syn-cluster-backup get schedule objects -o jsonpath='azure:{.spec.backend.s3.bucket}:/')
+export RESTIC_PASSWORD=$(kubectl -n syn-cluster-backup get secret objects-backup-password -o jsonpath='{.data.password}' | base64 --decode)
+export AZURE_ACCOUNT_NAME=$(kubectl get secret admin-credentials-minio-k8up -n syn-minio -o jsonpath='{.data.accesskey}' | base64 --decode)
+export AZURE_ACCOUNT_KEY=$(kubectl get secret admin-credentials-minio-k8up -n syn-minio -o jsonpath='{.data.secretkey}' | base64 --decode)
+----
+
+=== Obtaining restic configuration from catalog and vault
+
+1. Obtain the repository URL of the clusters catalog and export it to `REPO_URL`
++
+Get the URL from https://control.vshn.net/syn/lieutenantclusters.
+Alternatively, get it from the Lieutenant API or the Kubernetes API Lieutenant is running on.
++
+.Use the Lieutenant API
+[source,console]
+----
+REPO_URL=$(curl -sH "${LIEUTENANT_AUTH}" "https://${LIEUTENANT_URL}/clusters/${CLUSTER_ID}" | jq -r .gitRepo.url)
+----
++
+.Use the Kubernetes API
+[source,console]
+----
+REPO_URL=$(kubectl -n ${LIEUTENANT_NS} get cluster -o jsonpath='{.spec.gitRepoURL}' ${CLUSTER_ID})
+----
+
+2. Download and extract the cluster catalog
++
+[source,console]
+----
+mkdir catalog
+git archive --remote ${REPO_URL} master | tar -xC catalog
+----
+
+3. Login to vault
++
+[source,console]
+----
+export VAULT_ADDR=https://vault-prod.syn.vshn.net
+vault login -method=ldap username=<your username>
+----
+
+4. Export restic configuration
++
+[source,console]
+----
+export RESTIC_REPOSITORY=azure:$(yq -r '. | select(.kind == "Schedule").spec.backend.s3.bucket' catalog/manifests/cluster-backup/05_schedule.yaml):/
+
+PASSWORD_KEY="$(yq -r '. | select(.kind == "Secret" and .metadata.name == "objects-backup-password").stringData.password' catalog/manifests/cluster-backup/05_schedule.yaml | cut -d: -f2)"
+export RESTIC_PASSWORD=$(vault kv get -format json "clusters/kv/${PASSWORD_KEY%/*}" | jq -r ".data.data.${PASSWORD_KEY##*/}")
+
+ID_KEY="$(yq -r '. | select(.kind == "Secret" and .metadata.name == "object-backup-s3-credentials").stringData.username' catalog/manifests/cluster-backup/05_schedule.yaml | cut -d: -f2)"
+export AZURE_ACCOUNT_NAME=$(vault kv get -format json "clusters/kv/${ID_KEY%/*}" | jq -r ".data.data.${ID_KEY##*/}")
+
+SECRET_KEY="$(yq -r '. | select(.kind == "Secret" and .metadata.name == "object-backup-s3-credentials").stringData.password' catalog/manifests/cluster-backup/05_schedule.yaml | cut -d: -f2)"
+export AZURE_ACCOUNT_KEY=$(vault kv get -format json "clusters/kv/${SECRET_KEY%/*}" | jq -r ".data.data.${SECRET_KEY##*/}")
+----
+
+== Identify and retrieve snapshot
+
+1. List the available snapshots.
+   Identify the one you do want to restore.
+   Take note of its `ID`.
++
+[source,console]
+----
+restic snapshots
+----
+
+2. Retrieve the backup archive
++
+[source,console]
+----
+restic restore <ID> --target cluster-backup-object-restore-$(date +%F)
+----
+
+== Extract and prepare files
+
+1. List files in the backup.
+   Take note of the path containing the required files.
++
+[source,console]
+----
+tar tvf syn-cluster-backup-object-dumper.tar.gz
+----
+
+2. Extract required files.
+   If all files should be extracted, `path/inside/archive` can be omitted.
+   Files will be put in the directory `restore` within the current working directory.
++
+[source,console]
+----
+mkdir restore
+tar -C restore -xf syn-cluster-backup-object-dumper.tar.gz [path/inside/archive]
+----
+
+3. Prepare files
++
+Depending on the restore requirements, the extracted files need to be altered before they can be applied to the cluster.
+
+== Apply objects
+
+Apply the extracted and prepared objects to the target cluster.
+
+.Apply single file
+[source,console]
+----
+kubectl --as cluster-admin apply -f <path/to/file>
+----
+
+.Apply all files within a directory
+[source,console]
+----
+kubectl --as cluster-admin apply -Rf <path/to/dir>
+----

--- a/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
+++ b/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
@@ -1,4 +1,4 @@
-= AKS Recover cluster objects from Azure Blob Storage backup
+= Recover cluster objects from Azure Blob Storage backup
 
 == Prerequisites
 

--- a/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
+++ b/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
@@ -4,7 +4,7 @@
 
 * Executables used in this guide:
 ** `kubectl`
-** `yq`
+** https://github.com/kislyuk/yq[yq: Command-line YAML/XML/TOML processor] installable via `pip3 install yq`
 ** `restic`
 * API access to the target cluster
 

--- a/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
+++ b/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
@@ -39,20 +39,20 @@ Get the URL from https://control.vshn.net/syn/lieutenantclusters.
 Alternatively, get it from the Lieutenant API or the Kubernetes API Lieutenant is running on.
 +
 .Use the Lieutenant API
-[source,console]
+[source,bash]
 ----
 REPO_URL=$(curl -sH "${LIEUTENANT_AUTH}" "https://${LIEUTENANT_URL}/clusters/${CLUSTER_ID}" | jq -r .gitRepo.url)
 ----
 +
 .Use the Kubernetes API
-[source,console]
+[source,bash]
 ----
 REPO_URL=$(kubectl -n ${LIEUTENANT_NS} get cluster -o jsonpath='{.spec.gitRepoURL}' ${CLUSTER_ID})
 ----
 
 . Download and extract the cluster catalog
 +
-[source,console]
+[source,bash]
 ----
 mkdir catalog
 git archive --remote ${REPO_URL} master | tar -xC catalog
@@ -60,7 +60,7 @@ git archive --remote ${REPO_URL} master | tar -xC catalog
 
 . Login to Vault
 +
-[source,console]
+[source,bash]
 ----
 export VAULT_ADDR=https://vault-prod.syn.vshn.net
 vault login -method=ldap username=<your username>
@@ -68,7 +68,7 @@ vault login -method=ldap username=<your username>
 
 . Export restic configuration
 +
-[source,console]
+[source,bash]
 ----
 export RESTIC_REPOSITORY=azure:$(yq -r '. | select(.kind == "Schedule").spec.backend.s3.bucket' catalog/manifests/cluster-backup/05_schedule.yaml):/
 
@@ -95,7 +95,7 @@ restic snapshots
 
 . Retrieve the backup archive
 +
-[source,console]
+[source,bash]
 ----
 restic restore <ID> --target cluster-backup-object-restore-$(date +%F)
 ----
@@ -105,7 +105,7 @@ restic restore <ID> --target cluster-backup-object-restore-$(date +%F)
 . List files in the backup.
    Take note of the path containing the required files.
 +
-[source,console]
+[source,bash]
 ----
 tar tvf syn-cluster-backup-object-dumper.tar.gz
 ----
@@ -114,7 +114,7 @@ tar tvf syn-cluster-backup-object-dumper.tar.gz
    If all files should be extracted, `path/inside/archive` can be omitted.
    Files will be put in the directory `restore` within the current working directory.
 +
-[source,console]
+[source,bash]
 ----
 mkdir restore
 tar -C restore -xf syn-cluster-backup-object-dumper.tar.gz [path/inside/archive]
@@ -129,13 +129,13 @@ Depending on the restore requirements, the extracted files need to be altered be
 Apply the extracted and prepared objects to the target cluster.
 
 .Apply single file
-[source,console]
+[source,bash]
 ----
 kubectl --as cluster-admin apply -f <path/to/file>
 ----
 
 .Apply all files within a directory
-[source,console]
+[source,bash]
 ----
 kubectl --as cluster-admin apply -Rf <path/to/dir>
 ----

--- a/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
+++ b/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
@@ -33,7 +33,7 @@ export AZURE_ACCOUNT_KEY=$(kubectl get secret admin-credentials-minio-k8up -n sy
 
 === Obtaining restic configuration from catalog and vault
 
-1. Obtain the repository URL of the clusters catalog and export it to `REPO_URL`
+1. Obtain the repository URL of the cluster's catalog and export it to `REPO_URL`
 +
 Get the URL from https://control.vshn.net/syn/lieutenantclusters.
 Alternatively, get it from the Lieutenant API or the Kubernetes API Lieutenant is running on.

--- a/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
+++ b/docs/modules/ROOT/pages/how-tos/aks_recover_from_backup.adoc
@@ -4,7 +4,7 @@
 
 * Executables used in this guide:
 ** `kubectl`
-** https://github.com/kislyuk/yq[yq: Command-line YAML/XML/TOML processor] installable via `pip3 install yq`
+** https://mikefarah.gitbook.io/yq[yq YAML processor] (Version 4 or higher)
 ** `restic`
 * API access to the target cluster
 

--- a/docs/modules/ROOT/partials/nav-howtos.adoc
+++ b/docs/modules/ROOT/partials/nav-howtos.adoc
@@ -2,6 +2,7 @@
 ** xref:rancher:ROOT:how-tos/eks_node_maintenance.adoc[Node Maintenance]
 * Azure AKS
 ** xref:rancher:ROOT:how-tos/aks_node_maintenance.adoc[Node and Control-Plane Maintenance]
+** xref:rancher:ROOT:how-tos/aks_recover_from_backup.adoc[Recover cluster objects from backup]
 * Google GKE
 ** xref:rancher:ROOT:how-tos/gke_node_maintenance.adoc[Node Maintenance]
 * K3S


### PR DESCRIPTION
AKS requires a specific documentation, because the backup
is happening via the MinIO Azure Blob Storage Gateway and
the restore is using Azure Blob Storage directly.